### PR TITLE
Activate all VGs before running the shrink script

### DIFF
--- a/infra.lvm_tools/shrink_lv/roles/shrink_lv/files/shrink-start.sh
+++ b/infra.lvm_tools/shrink_lv/roles/shrink_lv/files/shrink-start.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 disable_lvm_lock(){
     tmpfile=$(/usr/bin/mktemp)
     sed -e 's/\(^[[:space:]]*\)locking_type[[:space:]]*=[[:space:]]*[[:digit:]]/\1locking_type = 1/' /etc/lvm/lvm.conf >"$tmpfile"
@@ -13,8 +12,14 @@ disable_lvm_lock(){
     mv "$tmpfile" /etc/lvm/lvm.conf
 }
 
+activate_volume_groups(){
+    for vg in `/usr/sbin/lvm vgs -o name --noheading 2>/dev/null`; do
+        /usr/sbin/lvm vgchange -ay $vg
+    done
+}
 
 main() {
+    activate_volume_groups
     disable_lvm_lock
     /usr/bin/shrink.sh --all --fstab=/etc/fstab.root 1>&2 >/dev/kmsg
 }


### PR DESCRIPTION
By default, not all VGs are activated which can cause the script to fail Make sure to activate them before running the actual shrink script